### PR TITLE
support single `group-by` statement in `ResultProvider:findCount`

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -6,7 +6,7 @@ include __DIR__ . '/vendor/autoload.php';
 return Paysera\PhpCsFixerConfig\Config\PayseraConventionsConfig::create()
     ->setDefaultFinder(['src', 'tests'], [])
     ->setRiskyRules([
-        'Paysera/php_basic_comment_php_doc_necessity' => false,
+        'Paysera/php_basic_comment_php_doc_contents' => false,
         'Paysera/php_basic_code_style_splitting_in_several_lines' => false,
         'Paysera/php_basic_code_style_chained_method_calls' => false,
     ])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0
+### Fixed
+- support single `group-by` statement in `ResultProvider:findCount` - this enables to properly get count of grouped statements. 

--- a/src/Exception/InvalidGroupByException.php
+++ b/src/Exception/InvalidGroupByException.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Exception;
+
+class InvalidGroupByException extends PaginationException
+{
+    /**
+     * @var string
+     */
+    private $groupBy;
+
+    public function __construct(string $groupBy)
+    {
+        parent::__construct(sprintf(
+            'Calculating total-count only supported with single group-by, instead provided: "%s"',
+            $groupBy
+        ));
+        $this->groupBy = $groupBy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGroupBy(): string
+    {
+        return $this->groupBy;
+    }
+}

--- a/tests/Functional/Fixtures/ParentTestEntity.php
+++ b/tests/Functional/Fixtures/ParentTestEntity.php
@@ -33,6 +33,13 @@ class ParentTestEntity
     private $name;
 
     /**
+     * @var string|null
+     *
+     * @Column(type="string", nullable=true)
+     */
+    private $groupKey;
+
+    /**
      * @var ChildTestEntity[]|Collection
      *
      * @OneToMany(targetEntity="ChildTestEntity", mappedBy="parent")
@@ -96,6 +103,25 @@ class ParentTestEntity
             $this->addChild($child);
         }
 
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getGroupKey()
+    {
+        return $this->groupKey;
+    }
+
+    /**
+     * @param string|null $group
+     *
+     * @return $this
+     */
+    public function setGroupKey(string $groupKey): self
+    {
+        $this->groupKey = $groupKey;
         return $this;
     }
 }

--- a/tests/Functional/Fixtures/ParentTestEntity.php
+++ b/tests/Functional/Fixtures/ParentTestEntity.php
@@ -115,7 +115,7 @@ class ParentTestEntity
     }
 
     /**
-     * @param string|null $group
+     * @param string|null $groupKey
      *
      * @return $this
      */

--- a/tests/Functional/Service/Doctrine/ResultProviderTest.php
+++ b/tests/Functional/Service/Doctrine/ResultProviderTest.php
@@ -607,7 +607,7 @@ class ResultProviderTest extends DoctrineTestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testGetTotalCountForQuery_throws_exception_with_more_than_one_group_by_argument()
+    public function testGetTotalCountForQueryThrowsExceptionWithMoreThanOneGroupByArgument()
     {
         $entityManager = $this->createTestEntityManager();
         $this->createTestData($entityManager);
@@ -623,7 +623,7 @@ class ResultProviderTest extends DoctrineTestCase
         $this->resultProvider->getTotalCountForQuery($configuredQuery);
     }
 
-    public function testGetTotalCountForQuery_throws_exception_with_more_than_one_group_by_expression()
+    public function testGetTotalCountForQueryThrowsExceptionWithMoreThanOneGroupByExpression()
     {
         $entityManager = $this->createTestEntityManager();
         $this->createTestData($entityManager);
@@ -666,7 +666,7 @@ class ResultProviderTest extends DoctrineTestCase
             [
                 4,
                 $queryBuilder2,
-            ]
+            ],
         ];
     }
 }

--- a/tests/Functional/Service/Doctrine/ResultProviderTest.php
+++ b/tests/Functional/Service/Doctrine/ResultProviderTest.php
@@ -6,6 +6,7 @@ namespace Paysera\Pagination\Tests\Functional\Service\Doctrine;
 use Doctrine\ORM\QueryBuilder;
 use Paysera\Pagination\Entity\OrderingConfiguration;
 use Doctrine\ORM\EntityManager;
+use Paysera\Pagination\Exception\InvalidGroupByException;
 use Paysera\Pagination\Service\Doctrine\QueryAnalyser;
 use Paysera\Pagination\Entity\Doctrine\ConfiguredQuery;
 use Paysera\Pagination\Entity\OrderingPair;
@@ -40,6 +41,9 @@ class ResultProviderTest extends DoctrineTestCase
     {
         for ($parentIndex = 0; $parentIndex < 30; $parentIndex++) {
             $parent = (new ParentTestEntity())->setName(sprintf('P%s', $parentIndex));
+            if ($parentIndex % 10 === 0) {
+                $parent->setGroupKey(sprintf('group_%s', $parentIndex));
+            }
             $entityManager->persist($parent);
         }
 
@@ -603,24 +607,66 @@ class ResultProviderTest extends DoctrineTestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function getResultProviderForGetTotalCountForQuery()
+    public function testGetTotalCountForQuery_throws_exception_with_more_than_one_group_by_argument()
     {
         $entityManager = $this->createTestEntityManager();
         $this->createTestData($entityManager);
         $queryBuilder = $entityManager->createQueryBuilder()
             ->select('p')
             ->from('PaginationTest:ParentTestEntity', 'p')
+            ->groupBy('p.groupKey', 'p.name')
+        ;
+
+        $configuredQuery = (new ConfiguredQuery($queryBuilder))->setTotalCountNeeded(false);
+
+        $this->expectException(InvalidGroupByException::class);
+        $this->resultProvider->getTotalCountForQuery($configuredQuery);
+    }
+
+    public function testGetTotalCountForQuery_throws_exception_with_more_than_one_group_by_expression()
+    {
+        $entityManager = $this->createTestEntityManager();
+        $this->createTestData($entityManager);
+        $queryBuilder = $entityManager->createQueryBuilder()
+            ->select('p')
+            ->from('PaginationTest:ParentTestEntity', 'p')
+            ->groupBy('p.groupKey')
+            ->addGroupBy('p.name')
+        ;
+
+        $configuredQuery = (new ConfiguredQuery($queryBuilder))->setTotalCountNeeded(false);
+
+        $this->expectException(InvalidGroupByException::class);
+        $this->resultProvider->getTotalCountForQuery($configuredQuery);
+    }
+
+    public function getResultProviderForGetTotalCountForQuery()
+    {
+        $entityManager = $this->createTestEntityManager();
+        $this->createTestData($entityManager);
+        $queryBuilder1 = $entityManager->createQueryBuilder()
+            ->select('p')
+            ->from('PaginationTest:ParentTestEntity', 'p')
+        ;
+        $queryBuilder2 = $entityManager->createQueryBuilder()
+            ->select('p')
+            ->from('PaginationTest:ParentTestEntity', 'p')
+            ->groupBy('p.groupKey')
         ;
 
         return [
             [
                 30,
-                $queryBuilder,
+                $queryBuilder1,
             ],
             [
                 11,
-                (clone $queryBuilder)->andWhere('p.name LIKE :name')->setParameter('name', 'P2%'),
+                (clone $queryBuilder1)->andWhere('p.name LIKE :name')->setParameter('name', 'P2%'),
             ],
+            [
+                4,
+                $queryBuilder2,
+            ]
         ];
     }
 }


### PR DESCRIPTION
support single `group-by` statement in `ResultProvider:findCount` - this enables to properly get count of grouped statements.