### PR TITLE
Added ResultConfiguration, deprecates ConfiguredQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.1.0
-### Deprecated
-- `ConfiguredQuery` see `ResultConfiguration`
+## 1.2.0
 ### Added
-- `ResultConfiguration` replaces `ConfiguredQuery`. Provides new methods: `setItemTransformer`, `getItemTransformer`.
+- `ConfiguredQuery` provides new methods: `setItemTransformer`, `getItemTransformer`.
 Accepts `callable` type. Receives result item - return value replaces received item in result.
+
+## 1.1.0
+### Added
+- Support for datetime
 
 ## 1.0.0
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0
+### Deprecated
+- `ConfiguredQuery` see `ResultConfiguration`
+### Added
+- `ResultConfiguration` replaces `ConfiguredQuery`. Provides new methods: `setItemTransformer`, `getItemTransformer`.
+Accepts `callable` type. Receives result item - return value replaces received item in result.
+
 ## 1.0.0
 ### Fixed
 - support single `group-by` statement in `ResultProvider:findCount` - this enables to properly get count of grouped statements. 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Generally `ConfiguredQuery` holds internals related to `QueryBuilder` so it's re
 Example usage:
 ```php
 <?php
-use Paysera\Pagination\Entity\Doctrine\ResultConfiguration;
+use Paysera\Pagination\Entity\Doctrine\ConfiguredQuery;
 use Paysera\Pagination\Service\Doctrine\ResultProvider;
 use Paysera\Pagination\Service\CursorBuilder;
 use Paysera\Pagination\Service\Doctrine\QueryAnalyser;
@@ -131,7 +131,7 @@ $queryBuilder = $entityManager->createQueryBuilder()
     ->setParameter('param', 'some value')
 ;
 
-$configuredQuery = (new ResultConfiguration($queryBuilder))
+$configuredQuery = (new ConfiguredQuery($queryBuilder))
     ->addOrderingConfiguration(
         'my_field_name',
         (new OrderingConfiguration('m.field', 'field'))->setOrderAscending(true)
@@ -174,7 +174,7 @@ and to optimize the process.
 Using `ResultIterator`:
 ```php
 <?php
-use Paysera\Pagination\Entity\Doctrine\ResultConfiguration;
+use Paysera\Pagination\Entity\Doctrine\ConfiguredQuery;
 use Paysera\Pagination\Service\Doctrine\ResultIterator;
 use Paysera\Pagination\Service\CursorBuilder;
 use Paysera\Pagination\Service\Doctrine\QueryAnalyser;
@@ -182,9 +182,9 @@ use Paysera\Pagination\Service\Doctrine\ResultProvider;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Psr\Log\NullLogger;
 
-/** @var ResultConfiguration $resultConfiguration */
+/** @var ConfiguredQuery $configuredQuery */
 
-$resultIterator = new ResultIterator(
+$configuredQuery = new ResultIterator(
     new ResultProvider(
         new QueryAnalyser(),
         new CursorBuilder(PropertyAccess::createPropertyAccessor())
@@ -193,7 +193,7 @@ $resultIterator = new ResultIterator(
     $defaultLimit = 1000
 );
 
-foreach ($this->resultIterator->iterate($resultConfiguration) as $item) {
+foreach ($this->resultIterator->iterate($configuredQuery) as $item) {
     // process $item where flush is not needed
     // for example, send ID or other data to working queue, process files etc.
 }
@@ -203,7 +203,7 @@ foreach ($this->resultIterator->iterate($resultConfiguration) as $item) {
 Using `FlushingResultIterator`:
 ```php
 <?php
-use Paysera\Pagination\Entity\Doctrine\ResultConfiguration;
+use Paysera\Pagination\Entity\Doctrine\ConfiguredQuery;
 use Paysera\Pagination\Service\Doctrine\FlushingResultIterator;
 use Paysera\Pagination\Service\CursorBuilder;
 use Paysera\Pagination\Service\Doctrine\QueryAnalyser;
@@ -212,10 +212,10 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Psr\Log\NullLogger;
 use Doctrine\ORM\EntityManagerInterface;
 
-/** @var ResultConfiguration $resultConfiguration */
+/** @var ConfiguredQuery $configuredQuery */
 /** @var EntityManagerInterface $entityManager */
 
-$resultIterator = new FlushingResultIterator(
+$configuredQuery = new FlushingResultIterator(
     new ResultProvider(
         new QueryAnalyser(),
         new CursorBuilder(PropertyAccess::createPropertyAccessor())
@@ -225,7 +225,7 @@ $resultIterator = new FlushingResultIterator(
     $entityManager
 );
 
-foreach ($this->resultIterator->iterate($resultConfiguration) as $item) {
+foreach ($this->resultIterator->iterate($configuredQuery) as $item) {
     // process $item or other entities where flush will be called after each page
     // for example:
     $item->setTitle(formatTitleFor($item));

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ composer require paysera/lib-pagination
 Use `ResultProvider` class (service) to provide the result.
 
 To get the result, two arguments are needed:
-- `ResultConfiguration`. This is wrapper around `QueryBuilder` and has configuration for available ordering fields,
+- `ConfiguredQuery`. This is wrapper around `QueryBuilder` and has configuration for available ordering fields,
 maximum offset, result item transformation and whether total count should be calculated;
 - `Pager`. This holds parameters provided by the user: offset or after/before cursor, limit and ordering directions.
 
@@ -184,7 +184,7 @@ use Psr\Log\NullLogger;
 
 /** @var ConfiguredQuery $configuredQuery */
 
-$configuredQuery = new ResultIterator(
+$resultIterator = new ResultIterator(
     new ResultProvider(
         new QueryAnalyser(),
         new CursorBuilder(PropertyAccess::createPropertyAccessor())
@@ -215,7 +215,7 @@ use Doctrine\ORM\EntityManagerInterface;
 /** @var ConfiguredQuery $configuredQuery */
 /** @var EntityManagerInterface $entityManager */
 
-$configuredQuery = new FlushingResultIterator(
+$resultIterator = new FlushingResultIterator(
     new ResultProvider(
         new QueryAnalyser(),
         new CursorBuilder(PropertyAccess::createPropertyAccessor())

--- a/src/Entity/Doctrine/ConfiguredQuery.php
+++ b/src/Entity/Doctrine/ConfiguredQuery.php
@@ -9,10 +9,6 @@ use Paysera\Pagination\Exception\InvalidOrderByException;
 use InvalidArgumentException;
 use RuntimeException;
 
-/**
- * @deprecated Will be removed with next major version
- * @see ResultConfiguration
- */
 class ConfiguredQuery
 {
     /**

--- a/src/Entity/Doctrine/ConfiguredQuery.php
+++ b/src/Entity/Doctrine/ConfiguredQuery.php
@@ -9,6 +9,10 @@ use Paysera\Pagination\Exception\InvalidOrderByException;
 use InvalidArgumentException;
 use RuntimeException;
 
+/**
+ * @deprecated Will be removed with next major version
+ * @see ResultConfiguration
+ */
 class ConfiguredQuery
 {
     /**
@@ -30,6 +34,11 @@ class ConfiguredQuery
      * @var int|null
      */
     private $maximumOffset;
+
+    /**
+     * @var callable
+     */
+    private $itemTransformer;
 
     public function __construct(QueryBuilder $queryBuilder)
     {
@@ -123,5 +132,20 @@ class ConfiguredQuery
         }
 
         return $this->maximumOffset;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getItemTransformer()
+    {
+        return $this->itemTransformer;
+    }
+
+    public function setItemTransformer(callable $itemTransformer): self
+    {
+        $this->itemTransformer = $itemTransformer;
+
+        return $this;
     }
 }

--- a/src/Entity/Doctrine/ResultConfiguration.php
+++ b/src/Entity/Doctrine/ResultConfiguration.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Entity\Doctrine;
+
+class ResultConfiguration extends ConfiguredQuery
+{
+}

--- a/src/Entity/Doctrine/ResultConfiguration.php
+++ b/src/Entity/Doctrine/ResultConfiguration.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace Paysera\Pagination\Entity\Doctrine;
-
-class ResultConfiguration extends ConfiguredQuery
-{
-}

--- a/src/Service/Doctrine/ResultProvider.php
+++ b/src/Service/Doctrine/ResultProvider.php
@@ -73,7 +73,8 @@ class ResultProvider
             ->setPreviousCursor($previousCursor)
             ->setNextCursor($nextCursor)
             ->setHasPrevious($this->existsBeforeCursor($previousCursor, $analysedQuery))
-            ->setHasNext($this->existsAfterCursor($nextCursor, $analysedQuery));
+            ->setHasNext($this->existsAfterCursor($nextCursor, $analysedQuery))
+        ;
     }
 
     private function findItems(AnalysedQuery $analysedQuery, Pager $pager)
@@ -207,7 +208,8 @@ class ResultProvider
                 ->setPreviousCursor($pager->getBefore())
                 ->setNextCursor($nextCursor)
                 ->setHasPrevious(false)
-                ->setHasNext($this->existsAfterCursor($nextCursor, $analysedQuery));
+                ->setHasNext($this->existsAfterCursor($nextCursor, $analysedQuery))
+            ;
 
         } elseif ($pager->getAfter() !== null) {
             $previousCursor = $this->cursorBuilder->invertCursorInclusion($pager->getAfter());
@@ -215,7 +217,8 @@ class ResultProvider
                 ->setPreviousCursor($previousCursor)
                 ->setNextCursor($pager->getAfter())
                 ->setHasPrevious($this->existsBeforeCursor($previousCursor, $analysedQuery))
-                ->setHasNext(false);
+                ->setHasNext(false)
+            ;
 
         } elseif ($pager->getOffset() !== null && $pager->getOffset() > 0) {
             return $this->buildResultForTooLargeOffset($analysedQuery);
@@ -224,7 +227,8 @@ class ResultProvider
 
         return (new Result())
             ->setHasPrevious(false)
-            ->setHasNext(false);
+            ->setHasNext(false)
+        ;
     }
 
     private function buildResultForZeroLimit(AnalysedQuery $analysedQuery, Pager $zeroLimitPager): Result
@@ -244,8 +248,8 @@ class ResultProvider
             ->setPreviousCursor($previousCursor)
             ->setNextCursor($nextCursor)
             ->setHasPrevious($this->existsBeforeCursor($previousCursor, $analysedQuery))
-            ->setHasNext(true);
-
+            ->setHasNext(true)
+        ;
     }
 
     private function buildResultForTooLargeOffset(AnalysedQuery $analysedQuery): Result
@@ -265,7 +269,8 @@ class ResultProvider
         return $result
             ->setHasPrevious(true)
             ->setPreviousCursor($this->cursorBuilder->buildCursorWithIncludedItem($lastItemCursor))
-            ->setNextCursor($lastItemCursor);
+            ->setNextCursor($lastItemCursor)
+        ;
     }
 
     /**
@@ -277,7 +282,8 @@ class ResultProvider
         $reversedOrderingConfigurations = [];
         foreach ($orderingConfigurations as $orderingConfiguration) {
             $reversedOrderingConfigurations[] = (clone $orderingConfiguration)
-                ->setOrderAscending(!$orderingConfiguration->isOrderAscending());
+                ->setOrderAscending(!$orderingConfiguration->isOrderAscending())
+            ;
         }
         return $reversedOrderingConfigurations;
     }
@@ -286,7 +292,9 @@ class ResultProvider
     {
         $nextPager = (new Pager())
             ->setBefore($previousCursor)
-            ->setLimit(1);
+            ->setLimit(1)
+        ;
+
         return count($this->findItems($analysedQuery, $nextPager)) > 0;
     }
 
@@ -294,7 +302,9 @@ class ResultProvider
     {
         $nextPager = (new Pager())
             ->setAfter($nextCursor)
-            ->setLimit(1);
+            ->setLimit(1)
+        ;
+
         return count($this->findItems($analysedQuery, $nextPager)) > 0;
     }
 
@@ -329,13 +339,15 @@ class ResultProvider
         $countQueryBuilder = $analysedQuery->cloneQueryBuilder();
         $countQueryBuilder
             ->resetDQLPart('groupBy')
-            ->select(sprintf('count(distinct %s)', $groupByColumn));
+            ->select(sprintf('count(distinct %s)', $groupByColumn))
+        ;
 
         $nullQueryBuilder = $analysedQuery->cloneQueryBuilder()
             ->resetDQLPart('groupBy')
             ->select($analysedQuery->getRootAlias())
             ->setMaxResults(1)
-            ->andWhere($groupByColumn . ' is null');
+            ->andWhere($groupByColumn . ' is null')
+        ;
 
         $nonNullCount = (int)$countQueryBuilder->getQuery()->getSingleScalarResult();
         $nullExists = count($nullQueryBuilder->getQuery()->getScalarResult());

--- a/src/Service/Doctrine/ResultProvider.php
+++ b/src/Service/Doctrine/ResultProvider.php
@@ -34,6 +34,16 @@ class ResultProvider
 
         $result = $this->buildResult($analysedQuery, $pager);
 
+        if ($configuredQuery->getItemTransformer() !== null) {
+            $transformedItems = [];
+            foreach ($result->getItems() as $item) {
+                $callable = $configuredQuery->getItemTransformer();
+                $transformedItems[] = $callable($item);
+            }
+
+            $result->setItems($transformedItems);
+        }
+
         if ($configuredQuery->isTotalCountNeeded()) {
             $totalCount = $this->calculateTotalCount($pager, count($result->getItems()));
             if ($totalCount === null) {

--- a/src/Service/Doctrine/ResultProvider.php
+++ b/src/Service/Doctrine/ResultProvider.php
@@ -36,9 +36,9 @@ class ResultProvider
 
         if ($configuredQuery->getItemTransformer() !== null) {
             $transformedItems = [];
+            $transform = $configuredQuery->getItemTransformer();
             foreach ($result->getItems() as $item) {
-                $callable = $configuredQuery->getItemTransformer();
-                $transformedItems[] = $callable($item);
+                $transformedItems[] = $transform($item);
             }
 
             $result->setItems($transformedItems);

--- a/tests/Functional/Service/Doctrine/ResultIteratorTest.php
+++ b/tests/Functional/Service/Doctrine/ResultIteratorTest.php
@@ -135,9 +135,13 @@ class ResultIteratorTest extends DoctrineTestCase
         $configuredQuery->setItemTransformer(function ($item) {
             return $item->getName();
         });
-
-        $array = iterator_to_array($this->resultIterator->iterate($configuredQuery));
-        list($resultItem) = $array;
+        $resultArray = iterator_to_array($this->resultIterator->iterate($configuredQuery));
+        list($resultItem) = $resultArray;
         $this->assertEquals('P9', $resultItem);
+
+        $configuredQuery = new ConfiguredQuery($queryBuilder);
+        $resultArray = iterator_to_array($this->resultIterator->iterate($configuredQuery));
+        list($resultItem) = $resultArray;
+        $this->assertEquals('P9', $resultItem->getName());
     }
 }

--- a/tests/Functional/Service/Doctrine/ResultIteratorTest.php
+++ b/tests/Functional/Service/Doctrine/ResultIteratorTest.php
@@ -120,4 +120,24 @@ class ResultIteratorTest extends DoctrineTestCase
             return $logInfo[0] === 'info';
         }));
     }
+
+    public function testTransformResultItems()
+    {
+        $entityManager = $this->createTestEntityManager();
+        $this->createTestData($entityManager);
+
+        $queryBuilder = $entityManager->createQueryBuilder()
+            ->select('p')
+            ->from('PaginationTest:ParentTestEntity', 'p')
+        ;
+
+        $configuredQuery = new ConfiguredQuery($queryBuilder);
+        $configuredQuery->setItemTransformer(function ($item) {
+            return $item->getName();
+        });
+
+        $array = iterator_to_array($this->resultIterator->iterate($configuredQuery));
+        list($resultItem) = $array;
+        $this->assertEquals('P9', $resultItem);
+    }
 }


### PR DESCRIPTION
## 1.1.0
### Deprecated
- `ConfiguredQuery` see `ResultConfiguration`
### Added
- `ResultConfiguration` replaces `ConfiguredQuery`. Provides new methods: `setItemTransformer`, `getItemTransformer`.
Accepts `callable` type. Receives result item - return value replaces received item in result.