### PR TITLE
Add MongoDB ODM support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,20 @@
     },
     "require": {
         "php": ">=7.0",
-        "doctrine/orm": "^2.0",
         "psr/log": "^1.0",
         "symfony/property-access": "^2.8|^3.0|^4.0|^5.0",
         "ext-json": "*"
     },
     "require-dev": {
+        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/orm": "^2.0",
         "phpunit/phpunit": "^6.0",
         "friendsofphp/php-cs-fixer": "2.11.1",
         "paysera/lib-php-cs-fixer-config": "^2.0"
+    },
+    "suggest": {
+        "doctrine/mongodb-odm": "required to use pagination over Doctrine MongoDB ODM",
+        "doctrine/orm": "required to use pagination over Doctrine ORM"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Entity/ODM/AnalysedQuery.php
+++ b/src/Entity/ODM/AnalysedQuery.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Entity\ODM;
+
+use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
+use Paysera\Pagination\Entity\OrderingConfiguration;
+
+/**
+ * @internal
+ */
+class AnalysedQuery
+{
+    /**
+     * @var QueryBuilder
+     */
+    private $queryBuilder;
+
+    /**
+     * @var OrderingConfiguration[]
+     */
+    private $orderingConfigurations;
+
+    /**
+     * @return QueryBuilder
+     */
+    public function cloneQueryBuilder(): QueryBuilder
+    {
+        return clone $this->queryBuilder;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @return $this
+     */
+    public function setQueryBuilder(QueryBuilder $queryBuilder): self
+    {
+        $this->queryBuilder = $queryBuilder;
+        return $this;
+    }
+
+    /**
+     * @return OrderingConfiguration[]
+     */
+    public function getOrderingConfigurations(): array
+    {
+        return $this->orderingConfigurations;
+    }
+
+    /**
+     * @param OrderingConfiguration[] $orderingConfigurations
+     * @return $this
+     */
+    public function setOrderingConfigurations(array $orderingConfigurations): self
+    {
+        $this->orderingConfigurations = $orderingConfigurations;
+        return $this;
+    }
+}

--- a/src/Entity/ODM/ConfiguredQuery.php
+++ b/src/Entity/ODM/ConfiguredQuery.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Entity\ODM;
+
+use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
+use Paysera\Pagination\Entity\OrderingConfiguration;
+use Paysera\Pagination\Exception\InvalidOrderByException;
+use InvalidArgumentException;
+use RuntimeException;
+
+class ConfiguredQuery
+{
+    /**
+     * @var QueryBuilder
+     */
+    private $queryBuilder;
+
+    /**
+     * @var array|OrderingConfiguration[] associative, keys are strings for ordering fields
+     */
+    private $orderingConfigurations;
+
+    /**
+     * @var bool
+     */
+    private $totalCountNeeded;
+
+    /**
+     * @var int|null
+     */
+    private $maximumOffset;
+
+    /**
+     * @var callable
+     */
+    private $itemTransformer;
+
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+        $this->orderingConfigurations = [];
+        $this->totalCountNeeded = false;
+    }
+
+    public function addOrderingConfiguration(string $orderBy, OrderingConfiguration $configuration): self
+    {
+        if ($configuration->getAccessorPath() === null && $configuration->getAccessorClosure() === null) {
+            throw new InvalidArgumentException(
+                'Must set either accessorPath or accessorClosure for every OrderingConfiguration'
+            );
+        }
+        $this->orderingConfigurations[$orderBy] = $configuration;
+        return $this;
+    }
+
+    /**
+     * @param array|OrderingConfiguration[] $orderingConfigurations array of `orderBy => OrderingConfiguration` pairs
+     * @return ConfiguredQuery
+     */
+    public function addOrderingConfigurations(array $orderingConfigurations): self
+    {
+        foreach ($orderingConfigurations as $orderBy => $configuration) {
+            $this->addOrderingConfiguration($orderBy, $configuration);
+        }
+
+        return $this;
+    }
+
+    public function getOrderingConfigurationFor(string $orderBy): OrderingConfiguration
+    {
+        if (!isset($this->orderingConfigurations[$orderBy])) {
+            throw new InvalidOrderByException($orderBy);
+        }
+
+        return $this->orderingConfigurations[$orderBy];
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->queryBuilder;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTotalCountNeeded(): bool
+    {
+        return $this->totalCountNeeded;
+    }
+
+    /**
+     * @param bool $totalCountNeeded
+     * @return $this
+     */
+    public function setTotalCountNeeded(bool $totalCountNeeded): self
+    {
+        $this->totalCountNeeded = $totalCountNeeded;
+        return $this;
+    }
+
+    /**
+     * @param int $maximumOffset
+     * @return $this
+     */
+    public function setMaximumOffset(int $maximumOffset): self
+    {
+        $this->maximumOffset = $maximumOffset;
+        return $this;
+    }
+
+    public function hasMaximumOffset(): bool
+    {
+        return $this->maximumOffset !== null;
+    }
+
+    /**
+     * @return int
+     * @throws RuntimeException if maximum offset was not set. Check with hasMaximumOffset beforehand
+     */
+    public function getMaximumOffset(): int
+    {
+        if ($this->maximumOffset === null) {
+            throw new RuntimeException('Maximum offset was not set');
+        }
+
+        return $this->maximumOffset;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getItemTransformer()
+    {
+        return $this->itemTransformer;
+    }
+
+    public function setItemTransformer(callable $itemTransformer): self
+    {
+        $this->itemTransformer = $itemTransformer;
+
+        return $this;
+    }
+}

--- a/src/Service/ODM/FlushingResultIterator.php
+++ b/src/Service/ODM/FlushingResultIterator.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Service\ODM;
+
+use Doctrine\Persistence\ObjectManager;
+use Psr\Log\LoggerInterface;
+
+class FlushingResultIterator extends ResultIterator
+{
+    private $objectManager;
+
+    public function __construct(
+        ResultProvider $resultProvider,
+        LoggerInterface $logger,
+        int $defaultPageSize,
+        ObjectManager $objectManager
+    ) {
+        parent::__construct($resultProvider, $logger, $defaultPageSize);
+        $this->objectManager = $objectManager;
+    }
+
+    protected function handleCycleEnd()
+    {
+        $this->objectManager->flush();
+        $this->objectManager->clear();
+    }
+}

--- a/src/Service/ODM/QueryAnalyser.php
+++ b/src/Service/ODM/QueryAnalyser.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Service\ODM;
+
+use Paysera\Pagination\Entity\ODM\AnalysedQuery;
+use Paysera\Pagination\Entity\OrderingConfiguration;
+use Paysera\Pagination\Entity\ODM\ConfiguredQuery;
+use Paysera\Pagination\Entity\OrderingPair;
+use Paysera\Pagination\Entity\Pager;
+use Paysera\Pagination\Exception\TooLargeOffsetException;
+
+class QueryAnalyser
+{
+    const ID_FIELD = 'id';
+
+    /**
+     * @internal
+     * @param ConfiguredQuery $configuredQuery
+     * @param Pager $pager
+     * @return AnalysedQuery
+     */
+    public function analyseQuery(ConfiguredQuery $configuredQuery, Pager $pager)
+    {
+        $analysedQuery = $this->analyseQueryWithoutPager($configuredQuery);
+
+        if (
+            $pager->getOffset() !== null
+            && $configuredQuery->hasMaximumOffset()
+            && $pager->getOffset() > $configuredQuery->getMaximumOffset()
+        ) {
+            throw new TooLargeOffsetException($configuredQuery->getMaximumOffset(), $pager->getOffset());
+        }
+
+        $orderingConfigurations = $this->mapToOrderingConfigurations(
+            $configuredQuery,
+            $pager->getOrderingPairs()
+        );
+
+        return $analysedQuery
+            ->setOrderingConfigurations($orderingConfigurations)
+        ;
+    }
+
+    /**
+     * @internal
+     * @param ConfiguredQuery $configuredQuery
+     * @return AnalysedQuery
+     */
+    public function analyseQueryWithoutPager(ConfiguredQuery $configuredQuery)
+    {
+        $queryBuilder = $configuredQuery->getQueryBuilder();
+
+        return (new AnalysedQuery())
+            ->setQueryBuilder($queryBuilder)
+        ;
+    }
+
+    /**
+     * @param ConfiguredQuery $configuredQuery
+     * @param array|OrderingPair[] $orderingPairs
+     * @return array|OrderingConfiguration[]
+     */
+    private function mapToOrderingConfigurations(ConfiguredQuery $configuredQuery, array $orderingPairs)
+    {
+        $orderingConfigurations = [];
+        $idIncluded = false;
+        $defaultAscending = null;
+        $orderByIdExpression = self::ID_FIELD;
+
+        foreach ($orderingPairs as $orderingPair) {
+            $orderingConfiguration = $configuredQuery->getOrderingConfigurationFor($orderingPair->getOrderBy());
+
+            if ($orderingPair->isOrderingDirectionSet()) {
+                $orderingConfiguration->setOrderAscending($orderingPair->isOrderAscending());
+            }
+
+            if ($orderingConfiguration->getOrderByExpression() === $orderByIdExpression) {
+                $idIncluded = true;
+            }
+
+            if ($defaultAscending === null) {
+                $defaultAscending = $orderingConfiguration->isOrderAscending();
+            }
+
+            $orderingConfigurations[] = $orderingConfiguration;
+        }
+
+        if ($idIncluded) {
+            return $orderingConfigurations;
+        }
+
+        $orderingConfigurations[] = (new OrderingConfiguration($orderByIdExpression, self::ID_FIELD))
+            ->setOrderAscending($defaultAscending ?? false)
+        ;
+
+        return $orderingConfigurations;
+    }
+}

--- a/src/Service/ODM/ResultIterator.php
+++ b/src/Service/ODM/ResultIterator.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Service\ODM;
+
+use Paysera\Pagination\Entity\ODM\ConfiguredQuery;
+use Paysera\Pagination\Entity\Pager;
+use Psr\Log\LoggerInterface;
+use Generator;
+
+class ResultIterator
+{
+    private $resultProvider;
+    private $logger;
+    private $defaultPageSize;
+
+    public function __construct(
+        ResultProvider $resultProvider,
+        LoggerInterface $logger,
+        int $defaultPageSize
+    ) {
+        $this->resultProvider = $resultProvider;
+        $this->logger = $logger;
+        $this->defaultPageSize = $defaultPageSize;
+    }
+
+    public function iterate(ConfiguredQuery $configuredQuery, Pager $startPager = null): Generator
+    {
+        $pager = $startPager !== null ? clone $startPager : new Pager();
+        if ($pager->getLimit() === null) {
+            $pager->setLimit($this->defaultPageSize);
+        }
+
+        while (true) {
+            $result = $this->resultProvider->getResultForQuery($configuredQuery, $pager);
+
+            foreach ($result->getItems() as $item) {
+                yield $item;
+            }
+
+            $this->handleCycleEnd();
+
+            if (!$result->hasNext()) {
+                $this->logger->info('Finished iterating');
+                return;
+            }
+
+            $pager = (new Pager())
+                ->setOrderingPairs($pager->getOrderingPairs())
+                ->setLimit($pager->getLimit())
+                ->setAfter($result->getNextCursor())
+            ;
+
+            $this->logger->info('Continuing with iteration', ['after' => $result->getNextCursor()]);
+        }
+    }
+
+    protected function handleCycleEnd()
+    {
+        // intentionally empty – override in extended classes
+    }
+}

--- a/src/Service/ODM/ResultProvider.php
+++ b/src/Service/ODM/ResultProvider.php
@@ -1,0 +1,341 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Pagination\Service\ODM;
+
+use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
+use Paysera\Pagination\Entity\ODM\AnalysedQuery;
+use Paysera\Pagination\Entity\OrderingConfiguration;
+use Paysera\Pagination\Entity\ODM\ConfiguredQuery;
+use Paysera\Pagination\Entity\Pager;
+use Paysera\Pagination\Entity\Result;
+use Paysera\Pagination\Service\CursorBuilderInterface;
+
+class ResultProvider
+{
+    private $queryAnalyser;
+    private $cursorBuilder;
+
+    public function __construct(QueryAnalyser $queryAnalyser, CursorBuilderInterface $cursorBuilder)
+    {
+        $this->queryAnalyser = $queryAnalyser;
+        $this->cursorBuilder = $cursorBuilder;
+    }
+
+    public function getResultForQuery(ConfiguredQuery $configuredQuery, Pager $pager): Result
+    {
+        $analysedQuery = $this->queryAnalyser->analyseQuery($configuredQuery, $pager);
+
+        $result = $this->buildResult($analysedQuery, $pager);
+
+        if ($configuredQuery->getItemTransformer() !== null) {
+            $this->transformResultItems($configuredQuery->getItemTransformer(), $result);
+        }
+
+        if ($configuredQuery->isTotalCountNeeded()) {
+            $totalCount = $this->calculateTotalCount($pager, count($result->getItems()));
+            if ($totalCount === null) {
+                $totalCount = $this->findCount($analysedQuery);
+            }
+            $result->setTotalCount($totalCount);
+        }
+
+        return $result;
+    }
+
+//    public function getTotalCountForQuery(ConfiguredQuery $configuredQuery): int
+//    {
+//        $analysedQuery = $this->queryAnalyser->analyseQueryWithoutPager($configuredQuery);
+//
+//        return $this->findCount($analysedQuery);
+//    }
+
+    private function buildResult(AnalysedQuery $analysedQuery, Pager $pager)
+    {
+        $items = $this->findItems($analysedQuery, $pager);
+
+        if (count($items) === 0) {
+            return $this->buildResultForEmptyItems($analysedQuery, $pager);
+        }
+
+        $orderingConfigurations = $analysedQuery->getOrderingConfigurations();
+        $previousCursor = $this->cursorBuilder->getCursorFromItem($items[0], $orderingConfigurations);
+        $nextCursor = $this->cursorBuilder->getCursorFromItem($items[count($items) - 1], $orderingConfigurations);
+
+        return (new Result())
+            ->setItems($items)
+            ->setPreviousCursor($previousCursor)
+            ->setNextCursor($nextCursor)
+            ->setHasPrevious($this->existsBeforeCursor($previousCursor, $analysedQuery))
+            ->setHasNext($this->existsAfterCursor($nextCursor, $analysedQuery))
+        ;
+    }
+
+    private function findItems(AnalysedQuery $analysedQuery, Pager $pager)
+    {
+        $pagedQueryBuilder = $this->pageQueryBuilder($analysedQuery, $pager);
+        $query = $pagedQueryBuilder->getQuery();
+        $items = $query->execute()->toArray();
+
+        if ($pager->getBefore() !== null) {
+            return array_reverse($items);
+        }
+
+        return $items;
+    }
+
+    private function pageQueryBuilder(AnalysedQuery $analysedQuery, Pager $pager)
+    {
+        $queryBuilder = $analysedQuery->cloneQueryBuilder();
+
+        if ($pager->getLimit() !== null) {
+            $queryBuilder->limit($pager->getLimit());
+        }
+
+        $orderingConfigurations = $analysedQuery->getOrderingConfigurations();
+        if ($pager->getBefore() !== null) {
+            $orderingConfigurations = $this->reverseOrderingDirection($orderingConfigurations);
+        }
+
+        $this->applyOrdering($queryBuilder, $orderingConfigurations);
+
+        if ($pager->getOffset() !== null) {
+            $this->applyOffset($queryBuilder, $pager->getOffset());
+        } elseif ($pager->getBefore() !== null) {
+            $this->applyBefore($queryBuilder, $pager->getBefore(), $analysedQuery);
+        } elseif ($pager->getAfter() !== null) {
+            $this->applyAfter($queryBuilder, $pager->getAfter(), $analysedQuery);
+        }
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param array|OrderingConfiguration[] $orderingConfigurations
+     */
+    private function applyOrdering(QueryBuilder $queryBuilder, array $orderingConfigurations)
+    {
+        foreach ($orderingConfigurations as $orderingConfiguration) {
+            $queryBuilder->sort(
+                $orderingConfiguration->getOrderByExpression(),
+                $orderingConfiguration->isOrderAscending() ? 'ASC' : 'DESC'
+            );
+        }
+    }
+
+    private function applyOffset(QueryBuilder $queryBuilder, int $offset)
+    {
+        $queryBuilder->skip($offset);
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string $after
+     * @param AnalysedQuery $analysedQuery
+     */
+    private function applyAfter(QueryBuilder $queryBuilder, string $after, AnalysedQuery $analysedQuery)
+    {
+        $this->applyCursor($queryBuilder, $after, $analysedQuery, false);
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string $after
+     * @param AnalysedQuery $analysedQuery
+     */
+    private function applyBefore(QueryBuilder $queryBuilder, string $after, AnalysedQuery $analysedQuery)
+    {
+        $this->applyCursor($queryBuilder, $after, $analysedQuery, true);
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string $cursor
+     * @param AnalysedQuery $analysedQuery
+     * @param bool $invert
+     */
+    private function applyCursor(QueryBuilder $queryBuilder, string $cursor, AnalysedQuery $analysedQuery, bool $invert)
+    {
+        $orderingConfigurations = $analysedQuery->getOrderingConfigurations();
+        $parsedCursor = $this->cursorBuilder->parseCursor($cursor, count($orderingConfigurations));
+
+        $whereClause = $queryBuilder->expr();
+        $previousConditions = $queryBuilder->expr();
+        foreach ($orderingConfigurations as $index => $orderingConfiguration) {
+            $useLargerThan = $orderingConfiguration->isOrderAscending();
+            if ($invert) {
+                $useLargerThan = !$useLargerThan;
+            }
+            $sign = $useLargerThan ? '>' : '<';
+            if ($parsedCursor->isCursoredItemIncluded() && $index === count($orderingConfigurations) - 1) {
+                $sign .= '=';
+            }
+
+            $value = $parsedCursor->getElementAtIndex($index);
+            $currentCondition = clone $previousConditions;
+            $currentCondition->field($orderingConfiguration->getOrderByExpression());
+            switch ($sign) {
+                case '>':
+                    $currentCondition->gt($value);
+                    break;
+                case '>=':
+                    $currentCondition->gte($value);
+                    break;
+                case '<':
+                    $currentCondition->lt($value);
+                    break;
+                case '<=':
+                    $currentCondition->lte($value);
+                    break;
+            }
+
+            $whereClause->addOr($currentCondition);
+
+            $previousConditions->field($orderingConfiguration->getOrderByExpression())->equals($value);
+        }
+
+        $queryBuilder->addAnd($whereClause);
+    }
+
+    private function buildResultForEmptyItems(AnalysedQuery $analysedQuery, Pager $pager): Result
+    {
+        if ($pager->getLimit() === 0) {
+            return $this->buildResultForZeroLimit($analysedQuery, $pager);
+
+        } elseif ($pager->getBefore() !== null) {
+            $nextCursor = $this->cursorBuilder->invertCursorInclusion($pager->getBefore());
+            return (new Result())
+                ->setPreviousCursor($pager->getBefore())
+                ->setNextCursor($nextCursor)
+                ->setHasPrevious(false)
+                ->setHasNext($this->existsAfterCursor($nextCursor, $analysedQuery))
+            ;
+
+        } elseif ($pager->getAfter() !== null) {
+            $previousCursor = $this->cursorBuilder->invertCursorInclusion($pager->getAfter());
+            return (new Result())
+                ->setPreviousCursor($previousCursor)
+                ->setNextCursor($pager->getAfter())
+                ->setHasPrevious($this->existsBeforeCursor($previousCursor, $analysedQuery))
+                ->setHasNext(false)
+            ;
+
+        } elseif ($pager->getOffset() !== null && $pager->getOffset() > 0) {
+            return $this->buildResultForTooLargeOffset($analysedQuery);
+
+        }
+
+        return (new Result())
+            ->setHasPrevious(false)
+            ->setHasNext(false)
+        ;
+    }
+
+    private function buildResultForZeroLimit(AnalysedQuery $analysedQuery, Pager $zeroLimitPager): Result
+    {
+        $pager = (clone $zeroLimitPager)->setLimit(1);
+        $items = $this->findItems($analysedQuery, $pager);
+
+        if (count($items) === 0) {
+            return $this->buildResultForEmptyItems($analysedQuery, $pager);
+        }
+
+        $orderingConfigurations = $analysedQuery->getOrderingConfigurations();
+        $previousCursor = $this->cursorBuilder->getCursorFromItem($items[0], $orderingConfigurations);
+        $nextCursor = $this->cursorBuilder->buildCursorWithIncludedItem($previousCursor);
+
+        return (new Result())
+            ->setPreviousCursor($previousCursor)
+            ->setNextCursor($nextCursor)
+            ->setHasPrevious($this->existsBeforeCursor($previousCursor, $analysedQuery))
+            ->setHasNext(true)
+        ;
+    }
+
+    private function buildResultForTooLargeOffset(AnalysedQuery $analysedQuery): Result
+    {
+        $result = (new Result())->setHasNext(false);
+
+        $pagerForLastElement = (new Pager())->setLimit(1);
+        $modifiedAnalysedQuery = (clone $analysedQuery)->setOrderingConfigurations(
+            $this->reverseOrderingDirection($analysedQuery->getOrderingConfigurations())
+        );
+        $items = $this->findItems($modifiedAnalysedQuery, $pagerForLastElement);
+        if (count($items) === 0) {
+            return $result->setHasPrevious(false);
+        }
+
+        $lastItemCursor = $this->cursorBuilder->getCursorFromItem($items[0], $modifiedAnalysedQuery->getOrderingConfigurations());
+        return $result
+            ->setHasPrevious(true)
+            ->setPreviousCursor($this->cursorBuilder->buildCursorWithIncludedItem($lastItemCursor))
+            ->setNextCursor($lastItemCursor)
+        ;
+    }
+
+    /**
+     * @param array|OrderingConfiguration[] $orderingConfigurations
+     * @return array|OrderingConfiguration[]
+     */
+    private function reverseOrderingDirection(array $orderingConfigurations): array
+    {
+        $reversedOrderingConfigurations = [];
+        foreach ($orderingConfigurations as $orderingConfiguration) {
+            $reversedOrderingConfigurations[] = (clone $orderingConfiguration)
+                ->setOrderAscending(!$orderingConfiguration->isOrderAscending())
+            ;
+        }
+        return $reversedOrderingConfigurations;
+    }
+
+    private function existsBeforeCursor(string $previousCursor, AnalysedQuery $analysedQuery)
+    {
+        $nextPager = (new Pager())
+            ->setBefore($previousCursor)
+            ->setLimit(1)
+        ;
+
+        return count($this->findItems($analysedQuery, $nextPager)) > 0;
+    }
+
+    private function existsAfterCursor(string $nextCursor, AnalysedQuery $analysedQuery)
+    {
+        $nextPager = (new Pager())
+            ->setAfter($nextCursor)
+            ->setLimit(1)
+        ;
+
+        return count($this->findItems($analysedQuery, $nextPager)) > 0;
+    }
+
+    private function calculateTotalCount(Pager $filter, int $resultCount)
+    {
+        if (
+            $filter->getOffset() !== null
+            && ($filter->getLimit() === null || $resultCount < $filter->getLimit())
+            && ($resultCount !== 0 || $filter->getOffset() === 0)
+        ) {
+            return $resultCount + $filter->getOffset();
+        }
+
+        return null;
+    }
+
+    private function findCount(AnalysedQuery $analysedQuery): int
+    {
+        $countQueryBuilder = $analysedQuery->cloneQueryBuilder();
+        $countQueryBuilder->count();
+        return $countQueryBuilder->getQuery()->execute();
+    }
+
+    private function transformResultItems(callable $transform, Result $result)
+    {
+        $transformedItems = [];
+        foreach ($result->getItems() as $item) {
+            $transformedItems[] = $transform($item);
+        }
+
+        $result->setItems($transformedItems);
+    }
+}


### PR DESCRIPTION
Hi guys,

First of all thank you for the great convenient lib, we are using it on our projects and glad this.
On the one of our project we want to use a such pagination with MongoDB and I want to suggest you to support this.
A lot of code are copy-pasted from ORM implementation and looks like we can create better abstractions to easily extend functionality for new storages and reduce code duplication.
Also I've moved `doctrine/orm` package to `required-dev` section of `composer.json` and also added `suggest` section since the library support multiple drivers now.

Please review and if this is ok I will add tests and fix your futher comments.

- [ ] Tests